### PR TITLE
0.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.9.4 - released 2019-05-08
 
-* Fixed issue #34: cypress-ntlm now waits 5 seconds for ntlm-proxy to start before giving up
+* Fixed issue #34: cypress-ntlm now waits up to 5 seconds for ntlm-proxy to start before giving up
 
 ## 0.9.3 - released 2019-04-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.4 - released 2019-05-08
+
+* Fixed issue #34: cypress-ntlm now waits 5 seconds for ntlm-proxy to start before giving up
+
 ## 0.9.3 - released 2019-04-30
 
 * Fixed issue #32: ntlm-proxy now respects the `NODE_TLS_REJECT_UNAUTHORIZED` environment variable

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ node_modules\\.bin\\ntlm-proxy-exit
 
 ### cypress-ntlm
 
-This binary is available in the `node_modules/.bin` folder. Use it to start Cypress with NTLM authentication configured. This command will fail if the proxy isn't already running.
+This binary is available in the `node_modules/.bin` folder. Use it to start Cypress with NTLM authentication configured. This command expects the ntlm-proxy to be running. If it isn't, cypress-ntlm will wait up to 5 seconds for ntlm-proxy to start. If ntlm-proxy still hasn't started, the cypress-ntlm command will fail.
 
 #### Example - Mac and Linux
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-ntlm-auth",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-ntlm-auth",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "NTLM authentication plugin for Cypress",
   "main": "index.js",
   "scripts": {

--- a/src/launcher/cypressNtlm.js
+++ b/src/launcher/cypressNtlm.js
@@ -5,7 +5,8 @@
 const portsFile = require('../util/portsFile');
 const cypress = require('cypress/lib/cli');
 
-if (portsFile.exists()) {
+checkPortsFileExists(5000, 200)
+.then(() => {
   portsFile.parse((ports, err) => {
     if (err) {
       throw err;
@@ -16,6 +17,33 @@ if (portsFile.exists()) {
     process.env.NO_PROXY = '';
     cypress.init();
   });
-} else {
-  throw new Error('ntlm-proxy must be started before this command');
+})
+.catch(() => {
+  process.stderr.write('ERROR: ntlm-proxy must be started before this command\n');
+  process.exit(1);
+});
+
+function checkPortsFileExists(timeout, interval) {
+  return new Promise((resolve, reject) => {
+    const timeoutTimerId = setTimeout(handleTimeout, timeout);
+    let intervalTimerId;
+
+    function handleTimeout() {
+      clearTimeout(intervalTimerId);
+      const error = new Error('Ports file not found before timeout');
+      error.name = 'PATH_CHECK_TIMED_OUT';
+      reject(error);
+    }
+
+    function handleInterval() {
+      if (portsFile.exists()) {
+        clearTimeout(timeoutTimerId);
+        resolve(true);
+      } else {
+        intervalTimerId = setTimeout(handleInterval, interval);
+      }
+    }
+
+    handleInterval();
+  });
 }


### PR DESCRIPTION
* Fixed issue #34: cypress-ntlm now waits up to 5 seconds for ntlm-proxy to start before giving up
