### PR TITLE
Force ntlmv1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.0-beta.3 - released 2019-07-23
+
+* Fix #60: NTLM version can now be set in the cy.ntlm call. Defaults to NTLMv2.
+
 ## 1.2.1 - released 2019-07-13
 
 * Made workstation field more consistent in NTLM messages. Fixes authentication issues with some NTLMv2 hosts.

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ The ntlm command is used to configure host/user mappings. After this command, al
 #### Syntax
 
 ```javascript
-cy.ntlm(ntlmHost, username, password, [domain, [workstation]]);
+cy.ntlm(ntlmHost, username, password, [domain, [workstation, [ntlmVersion]]]);
 ```
 
 * ntlmHost: protocol, hostname (and port if required) of the server where NTLM authentication shall be applied. This must NOT include the rest of the url (path and query) - only host level authentication is supported. Examples: `http://localhost:4200`, `https://ntlm.acme.com`
@@ -204,6 +204,7 @@ cy.ntlm(ntlmHost, username, password, [domain, [workstation]]);
 * password: the password for the account to authenticate with (see [Security advice](#Security-advice) regarding entering passwords)
 * domain (optional): the domain for the account to authenticate with (for AD account authentication)
 * workstation (optional): the workstation name of the client
+* ntlmVersion (optional): the version of the NTLM protocol to use. Valid values are 1 and 2. Defaults to 2 if not set. This can be useful for legacy hosts that don't support NTLMv2, or for certain scenarios where the NTLMv2 handshake fails (the plugin does not implement all features of NTLMv2 yet).
 
 The ntlm command may be called multiple times to setup multiple ntlmHosts, also with different credentials. If the ntlm command is called with the same ntlmHost again, it overwrites the credentials for that ntlmHost.
 
@@ -222,6 +223,11 @@ cy.visit('https://ntlm.acme.com');
 cy.ntlm('https://ntlm.acme.com', 'admin', 'secret', 'acme');
 // Access the ntlm site with user admin
 cy.visit('https://ntlm.acme.com');
+// Test actions and asserts here
+
+cy.ntlm('https://ntlm-legacy.acme.com', 'admin', 'secret', 'acme', undefined, 1);
+// Access the ntlm-legacy site with user admin using NTLMv1
+cy.visit('https://ntlm-legacy.acme.com');
 // Test actions and asserts here
 ```
 

--- a/src/commands/index.d.ts
+++ b/src/commands/index.d.ts
@@ -11,7 +11,7 @@ declare namespace Cypress {
   cy.ntlm('https://ntlm.acme.com', 'TheUser', 'ThePassword', 'TheDomain');
  ```
     */
-    ntlm(ntlmHost: string, username: string, password: string, domain?: string, workstation?: string): Chainable<any>
+    ntlm(ntlmHost: string, username: string, password: string, domain?: string, workstation?: string, ntlmVersion?: number): Chainable<any>
 
     /**
      * Reset NTLM authentication for all configured hosts. Recommended before/after tests.

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -13,7 +13,7 @@ const ConfigValidator = require('../util/config.validator').ConfigValidator;
   cy.ntlm('https://ntlm.acme.com', 'TheUser', 'ThePassword', 'TheDomain');
  ```
  */
-const ntlm = (ntlmHost, username, password, domain, workstation) => {
+const ntlm = (ntlmHost, username, password, domain, workstation, ntlmVersion) => {
   const log = {
     name: 'ntlm',
     message: { ntlmHost, username }
@@ -30,7 +30,8 @@ const ntlm = (ntlmHost, username, password, domain, workstation) => {
     username: username,
     password: password,
     domain: domain,
-    workstation: workstation
+    workstation: workstation,
+    ntlmVersion: ntlmVersion || 2
   };
   let validationResult = ConfigValidator.validate(ntlmConfig);
   if (!validationResult.ok) {
@@ -58,6 +59,7 @@ const ntlm = (ntlmHost, username, password, domain, workstation) => {
       username: username,
       domain: domain,
       workstation: workstation,
+      ntlmVersion: ntlmVersion || 2,
       result: result
     };
   };

--- a/src/models/ntlm.config.model.ts
+++ b/src/models/ntlm.config.model.ts
@@ -4,4 +4,5 @@ export interface NtlmConfig {
   password: string;
   domain?: string;
   workstation?: string;
+  ntlmVersion: number;
 }

--- a/src/proxy/config.store.ts
+++ b/src/proxy/config.store.ts
@@ -19,7 +19,8 @@ export class ConfigStore implements IConfigStore {
       username: config.username,
       password: config.password,
       domain: config.domain ? config.domain.toUpperCase() : undefined,
-      workstation: config.workstation ? config.workstation.toUpperCase() : undefined
+      workstation: config.workstation ? config.workstation.toUpperCase() : undefined,
+      ntlmVersion: config.ntlmVersion
     };
 
     this.ntlmHosts[ntlmHostUrl.href] = hostConfig;

--- a/src/proxy/ntlm.manager.ts
+++ b/src/proxy/ntlm.manager.ts
@@ -28,7 +28,7 @@ export class NtlmManager implements INtlmManager {
     let fullUrl = ntlmHostUrl.href + ntlmHostUrl.path;
     context.setState(ntlmHostUrl, NtlmStateEnum.NotAuthenticated);
     let config = this._configStore.get(ntlmHostUrl);
-    let type1msg = ntlm.createType1Message(2, config.workstation, config.domain);
+    let type1msg = ntlm.createType1Message(config.ntlmVersion, config.workstation, config.domain);
     let requestOptions: https.RequestOptions = {
       method: ctx.proxyToServerRequestOptions.method,
       path: ctx.proxyToServerRequestOptions.path,

--- a/src/util/config.validator.ts
+++ b/src/util/config.validator.ts
@@ -9,8 +9,9 @@ export class ConfigValidator {
 
     if (!config.ntlmHost ||
         !config.username ||
-        !config.password) {
-      result.message = 'Incomplete configuration. ntlmHost, username and password are required fields.';
+        !config.password ||
+        !config.ntlmVersion) {
+      result.message = 'Incomplete configuration. ntlmHost, username, password and ntlmVersion are required fields.';
       return result;
     }
 
@@ -37,6 +38,11 @@ export class ConfigValidator {
     if (config.workstation &&
         !this.validateDomainOrWorkstation(config.workstation)) {
       result.message = 'Workstation contains invalid characters or is too long.';
+      return result;
+    }
+
+    if (config.ntlmVersion !== 1 && config.ntlmVersion !== 2) {
+      result.message = 'Invalid ntlmVersion. Must be 1 or 2.';
       return result;
     }
 

--- a/test/proxy/config.server.deep.spec.ts
+++ b/test/proxy/config.server.deep.spec.ts
@@ -9,12 +9,14 @@ import { DependencyInjection } from '../../src/proxy/dependency.injection';
 import { TYPES } from '../../src/proxy/dependency.injection.types';
 import { IConfigServer } from '../../src/proxy/interfaces/i.config.server';
 import { IConfigStore } from '../../src/proxy/interfaces/i.config.store';
+import { NtlmConfig } from '../../src/models/ntlm.config.model';
 
 describe('Config API (ConfigServer deep tests)', () => {
   let configApiUrl: string;
   let dependencyInjection = new DependencyInjection();
   let configServer: IConfigServer;
   let configStore: IConfigStore;
+  let hostConfig: NtlmConfig;
 
   before(async function () {
     configServer = dependencyInjection.get<IConfigServer>(TYPES.IConfigServer);
@@ -33,11 +35,12 @@ describe('Config API (ConfigServer deep tests)', () => {
 
   it('ntlm-config should return bad request if the username contains backslash', async function () {
     // Arrange
-    let hostConfig = {
+    hostConfig = {
       ntlmHost: 'http://localhost:5000',
       username: 'nisse\\nisse',
       password: 'dummy',
-      domain: 'mptest'
+      domain: 'mptest',
+      ntlmVersion: 2
     };
 
     // Act
@@ -49,11 +52,12 @@ describe('Config API (ConfigServer deep tests)', () => {
 
   it('ntlm-config should return bad request if the domain contains backslash', async function () {
     // Arrange
-    let hostConfig = {
+    hostConfig = {
       ntlmHost: 'http://localhost:5000',
       username: 'nisse',
       password: 'dummy',
-      domain: 'mptest\\mptest'
+      domain: 'mptest\\mptest',
+      ntlmVersion: 2
     };
 
     // Act
@@ -65,11 +69,12 @@ describe('Config API (ConfigServer deep tests)', () => {
 
   it('ntlm-config should return bad request if the ntlmHost includes a path', async function () {
     // Arrange
-    let hostConfig = {
+    hostConfig = {
       ntlmHost: 'http://localhost:5000/search',
       username: 'nisse',
       password: 'dummy',
-      domain: 'mptest'
+      domain: 'mptest',
+      ntlmVersion: 2
     };
 
     // Act
@@ -81,11 +86,12 @@ describe('Config API (ConfigServer deep tests)', () => {
 
   it('ntlm-config should return ok if the config is ok', async function () {
     // Arrange
-    let hostConfig = {
+    hostConfig = {
       ntlmHost: 'http://localhost:5000/',
       username: 'nisse',
       password: 'dummy',
-      domain: 'mptest'
+      domain: 'mptest',
+      ntlmVersion: 2
     };
 
     // Act
@@ -97,11 +103,12 @@ describe('Config API (ConfigServer deep tests)', () => {
 
   it('ntlm-config should allow reconfiguration', async function () {
     // Arrange
-    let hostConfig = {
+    hostConfig = {
       ntlmHost: 'http://localhost:5000/',
       username: 'nisse',
       password: 'dummy',
-      domain: 'mptest'
+      domain: 'mptest',
+      ntlmVersion: 2
     };
     let completeUrl = toCompleteUrl('http://localhost:5000', false);
 

--- a/test/proxy/http.proxy.spec.ts
+++ b/test/proxy/http.proxy.spec.ts
@@ -45,7 +45,8 @@ describe('Proxy for HTTP host with NTLM', function() {
       ntlmHost: httpUrl,
       username: 'nisse',
       password: 'manpower',
-      domain: 'mptst'
+      domain: 'mptst',
+      ntlmVersion: 2
     };
     coreServer = dependencyInjection.get<ICoreServer>(TYPES.ICoreServer);
     let ports = await coreServer.start(false, undefined, undefined, undefined);
@@ -271,7 +272,8 @@ describe('Proxy for HTTP host without NTLM', function() {
       ntlmHost: httpUrl,
       username: 'nisse',
       password: 'manpower',
-      domain: 'mptst'
+      domain: 'mptst',
+      ntlmVersion: 2
     };
     coreServer = dependencyInjection.get<ICoreServer>(TYPES.ICoreServer);
     let ports = await coreServer.start(false, undefined, undefined, undefined);

--- a/test/proxy/http.upstream.proxy.spec.ts
+++ b/test/proxy/http.upstream.proxy.spec.ts
@@ -50,7 +50,8 @@ describe('Proxy for HTTP host with NTLM and upstream proxy', function() {
       ntlmHost: httpUrl,
       username: 'nisse',
       password: 'manpower',
-      domain: 'mptst'
+      domain: 'mptst',
+      ntlmVersion: 2
     };
     coreServer = dependencyInjection.get<ICoreServer>(TYPES.ICoreServer);
     let ports = await coreServer.start(false, upstreamProxyUrl, undefined, undefined);

--- a/test/proxy/https.proxy.spec.ts
+++ b/test/proxy/https.proxy.spec.ts
@@ -45,7 +45,8 @@ describe('Proxy for HTTPS host with NTLM', function() {
       ntlmHost: httpsUrl,
       username: 'nisse',
       password: 'manpower',
-      domain: 'mptst'
+      domain: 'mptst',
+      ntlmVersion: 2
     };
     coreServer = dependencyInjection.get<ICoreServer>(TYPES.ICoreServer);
     let ports = await coreServer.start(false, undefined, undefined, undefined);
@@ -167,7 +168,8 @@ describe('Proxy for HTTPS host without NTLM', function() {
       ntlmHost: httpsUrl,
       username: 'nisse',
       password: 'manpower',
-      domain: 'mptst'
+      domain: 'mptst',
+      ntlmVersion: 2
     };
     coreServer = dependencyInjection.get<ICoreServer>(TYPES.ICoreServer);
     let ports = await coreServer.start(false, undefined, undefined, undefined);

--- a/test/proxy/https.upstream.proxy.spec.ts
+++ b/test/proxy/https.upstream.proxy.spec.ts
@@ -48,7 +48,8 @@ describe('Proxy for HTTPS host with NTLM and upstream proxy', function() {
       ntlmHost: httpsUrl,
       username: 'nisse',
       password: 'manpower',
-      domain: 'mptst'
+      domain: 'mptst',
+      ntlmVersion: 2
     };
     coreServer = dependencyInjection.get<ICoreServer>(TYPES.ICoreServer);
     let ports = await coreServer.start(false, undefined, upstreamProxyUrl, undefined);

--- a/test/proxy/ntlm.proxy.spec.ts
+++ b/test/proxy/ntlm.proxy.spec.ts
@@ -119,6 +119,7 @@ describe('NTLM Proxy authentication', function () {
       username: 'nisse',
       password: 'manpower',
       domain: 'mnpwr',
+      ntlmVersion: 2
     };
     remoteHostResponseWwwAuthHeader = 'test';
 
@@ -142,6 +143,7 @@ describe('NTLM Proxy authentication', function () {
       username: 'nisse',
       password: 'manpower',
       domain: 'mnpwr',
+      ntlmVersion: 2
     };
 
     // Act
@@ -164,6 +166,7 @@ describe('NTLM Proxy authentication', function () {
       username: 'nisse',
       password: 'manpower',
       domain: 'mnpwr',
+      ntlmVersion: 2
     };
 
     // Act
@@ -187,6 +190,7 @@ describe('NTLM Proxy authentication', function () {
       username: 'nisse',
       password: 'manpower',
       domain: 'mnpwr',
+      ntlmVersion: 2
     };
     let ports = await coreServer.start(false, undefined, undefined, undefined);
     _configApiUrl = ports.configApiUrl;

--- a/test/util/config.validator.spec.ts
+++ b/test/util/config.validator.spec.ts
@@ -13,6 +13,7 @@ describe('ConfigValidator', function() {
         ntlmHost: 'http://localhost:5000',
         username: 'nisse',
         password: 'manpwr',
+        ntlmVersion: 2
       };
     });
 
@@ -56,7 +57,8 @@ describe('ConfigValidator', function() {
       config = {
         ntlmHost: 'http://localhost:5000',
         username: 'nisse',
-        password: 'manpwr'
+        password: 'manpwr',
+        ntlmVersion: 2
       };
     });
 
@@ -100,7 +102,8 @@ describe('ConfigValidator', function() {
       config = {
         ntlmHost: 'http://localhost:5000',
         username: 'nisse',
-        password: 'manpwr'
+        password: 'manpwr',
+        ntlmVersion: 2
       };
     });
 
@@ -147,7 +150,8 @@ describe('ConfigValidator', function() {
       config = {
         ntlmHost: 'http://localhost:5000',
         username: 'nisse',
-        password: 'manpwr'
+        password: 'manpwr',
+        ntlmVersion: 2
       };
     });
 
@@ -187,6 +191,66 @@ describe('ConfigValidator', function() {
       chai.expect(result.ok).to.be.false;
       chai.expect(result.message).to.be.equal('Workstation contains invalid characters or is too long.');
     });
+  });
+
+  describe('ntlmVersion', function() {
+    let config: NtlmConfig;
+
+    beforeEach(function () {
+      config = {
+        ntlmHost: 'http://localhost:5000',
+        username: 'nisse',
+        password: 'manpwr',
+        ntlmVersion: 2
+      };
+    });
+
+    it('ntlmVersion 1 succeeds', function() {
+      // Arrange
+      config.ntlmVersion = 1;
+
+      // Act
+      let result = ConfigValidator.validate(config);
+
+      // Assert
+      chai.expect(result.ok).to.be.true;
+    });
+
+    it('ntlmVersion 2 succeeds', function() {
+      // Arrange
+      config.ntlmVersion = 2;
+
+      // Act
+      let result = ConfigValidator.validate(config);
+
+      // Assert
+      chai.expect(result.ok).to.be.true;
+    });
+
+
+    it('ntlmVersion -1 fails', function () {
+      // Arrange
+      config.ntlmVersion = -1;
+
+      // Act
+      let result = ConfigValidator.validate(config);
+
+      // Assert
+      chai.expect(result.ok).to.be.false;
+      chai.expect(result.message).to.be.equal('Invalid ntlmVersion. Must be 1 or 2.');
+    });
+
+    it('ntlmVersion 200 fails', function () {
+      // Arrange
+      config.ntlmVersion = 200;
+
+      // Act
+      let result = ConfigValidator.validate(config);
+
+      // Assert
+      chai.expect(result.ok).to.be.false;
+      chai.expect(result.message).to.be.equal('Invalid ntlmVersion. Must be 1 or 2.');
+    });
 
   });
 
@@ -197,7 +261,8 @@ describe('ConfigValidator', function() {
       config = {
         ntlmHost: 'http://localhost:5000',
         username: 'nisse',
-        password: 'manpwr'
+        password: 'manpwr',
+        ntlmVersion: 2
       };
     });
 
@@ -210,7 +275,7 @@ describe('ConfigValidator', function() {
 
       // Assert
       chai.expect(result.ok).to.be.false;
-      chai.expect(result.message).to.be.equal('Incomplete configuration. ntlmHost, username and password are required fields.');
+      chai.expect(result.message).to.be.equal('Incomplete configuration. ntlmHost, username, password and ntlmVersion are required fields.');
     });
 
     it('Does return error if username is missing', function () {
@@ -222,7 +287,7 @@ describe('ConfigValidator', function() {
 
       // Assert
       chai.expect(result.ok).to.be.false;
-      chai.expect(result.message).to.be.equal('Incomplete configuration. ntlmHost, username and password are required fields.');
+      chai.expect(result.message).to.be.equal('Incomplete configuration. ntlmHost, username, password and ntlmVersion are required fields.');
     });
 
 
@@ -235,7 +300,19 @@ describe('ConfigValidator', function() {
 
       // Assert
       chai.expect(result.ok).to.be.false;
-      chai.expect(result.message).to.be.equal('Incomplete configuration. ntlmHost, username and password are required fields.');
+      chai.expect(result.message).to.be.equal('Incomplete configuration. ntlmHost, username, password and ntlmVersion are required fields.');
+    });
+
+    it('Does return error if ntlmVersion is missing', function () {
+      // Arrange
+      delete config.ntlmVersion;
+
+      // Act
+      let result = ConfigValidator.validate(config);
+
+      // Assert
+      chai.expect(result.ok).to.be.false;
+      chai.expect(result.message).to.be.equal('Incomplete configuration. ntlmHost, username, password and ntlmVersion are required fields.');
     });
   });
 });


### PR DESCRIPTION
* Fix #60: NTLM version can now be set in the cy.ntlm call. Defaults to NTLMv2.
