### PR TITLE
Full handshake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.3.0-beta.4 - released 2019-07-29
+
+* Fix #62, #64 and #65: Implemented full NTLM handshake. Authentication is only initiated when the server sends a 401 challenge response which indicates that NTLM authentication is supported. This should resolve the issues seen by some users for:
+  * CORS preflight messages
+  * when the server repeats the challenge after first authentication
+  * subsites within a host that does not use NTLM authentication.
+
 ## 1.3.0-beta.3 - released 2019-07-23
 
 * Fix #60: NTLM version can now be set in the cy.ntlm call. Defaults to NTLMv2.

--- a/README.md
+++ b/README.md
@@ -191,7 +191,8 @@ If the host you are testing is located on the internet (not your intranet) the N
 
 ### cy.ntlm(ntlmHost, username, password, [domain, [workstation]])
 
-The ntlm command is used to configure host/user mappings. After this command, all network communication from cypress to the specified host will be initiated with a NTLM login handshake with the specified user. This includes calls to `cy.visit(host)`, `cy.request(host)` and indirect network communication (when the browser fetches additional resources after the `cy.visit(host)` call).
+The ntlm command is used to configure host/user mappings. After this command, all network communication from cypress to the specified host is monitored by the ntlm-proxy. If the server sends an authentication challenge, the ntlm-proxy will perform a NTLM login handshake with the configured user.
+Note that "all network communication" includes calls to `cy.visit(host)`, `cy.request(host)` and indirect network communication (when the browser fetches additional resources after the `cy.visit(host)` call).
 
 #### Syntax
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-ntlm-auth",
-  "version": "1.3.0-beta.2",
+  "version": "1.3.0-beta.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-ntlm-auth",
-  "version": "1.3.0-beta.2",
+  "version": "1.3.0-beta.3",
   "description": "NTLM authentication plugin for Cypress",
   "main": "dist/proxy/main.js",
   "scripts": {

--- a/src/proxy/connection.context.ts
+++ b/src/proxy/connection.context.ts
@@ -8,6 +8,7 @@ export class ConnectionContext implements IConnectionContext {
   private _agent: any;
   private _ntlmHost?: CompleteUrl;
   private _ntlmState: NtlmStateEnum = NtlmStateEnum.NotAuthenticated;
+  private _requestBody = Buffer.alloc(0);
 
   get agent(): any {
     return this._agent;
@@ -20,6 +21,14 @@ export class ConnectionContext implements IConnectionContext {
     let auth = (this._ntlmHost !== undefined &&
       this._ntlmHost.href === ntlmHostUrl.href &&
       this._ntlmState === NtlmStateEnum.Authenticated);
+    return auth;
+  }
+
+  isNewOrAuthenticated(ntlmHostUrl: CompleteUrl): boolean {
+    let auth = this._ntlmHost === undefined ||
+      (this._ntlmHost !== undefined &&
+       this._ntlmHost.href === ntlmHostUrl.href &&
+       this._ntlmState === NtlmStateEnum.Authenticated);
     return auth;
   }
 
@@ -39,5 +48,17 @@ export class ConnectionContext implements IConnectionContext {
     if (this._ntlmHost !== undefined && this._ntlmHost.href === ntlmHostUrl.href) {
       this._ntlmState = NtlmStateEnum.NotAuthenticated;
     }
+  }
+
+  clearRequestBody() {
+    this._requestBody = Buffer.alloc(0);
+  }
+
+  addToRequestBody(chunk: Buffer) {
+    this._requestBody = Buffer.concat([this._requestBody, chunk]);
+  }
+
+  getRequestBody(): Buffer {
+    return this._requestBody;
   }
 }

--- a/src/proxy/interfaces/i.connection.context.ts
+++ b/src/proxy/interfaces/i.connection.context.ts
@@ -5,7 +5,12 @@ export interface IConnectionContext {
   agent: any;
 
   isAuthenticated(ntlmHostUrl: CompleteUrl): boolean;
+  isNewOrAuthenticated(ntlmHostUrl: CompleteUrl): boolean;
   getState(ntlmHostUrl: CompleteUrl): NtlmStateEnum;
   setState(ntlmHostUrl: CompleteUrl, authState: NtlmStateEnum): void;
   resetState(ntlmHostUrl: CompleteUrl): void;
+
+  clearRequestBody(): void;
+  addToRequestBody(chunk: Buffer): void;
+  getRequestBody(): Buffer;
 }

--- a/src/proxy/interfaces/i.ntlm.manager.ts
+++ b/src/proxy/interfaces/i.ntlm.manager.ts
@@ -1,8 +1,10 @@
 import { IContext } from '@bjowes/http-mitm-proxy';
 import { CompleteUrl } from '../../models/complete.url.model';
 import { IConnectionContext } from './i.connection.context';
+import http from 'http';
 
 export interface INtlmManager {
   ntlmHandshake(ctx: IContext, ntlmHostUrl: CompleteUrl, context: IConnectionContext, callback: (error?: NodeJS.ErrnoException) => void): void;
-  ntlmHandshakeResponse(ctx: IContext, ntlmHostUrl: CompleteUrl, context: IConnectionContext, callback: (error?: NodeJS.ErrnoException) => void): void;
+  acceptsNtlmAuthentication(res: http.IncomingMessage): boolean;
+  canHandleNtlmAuthentication(res: http.IncomingMessage): boolean;
 }

--- a/src/proxy/ntlm.manager.ts
+++ b/src/proxy/ntlm.manager.ts
@@ -24,7 +24,7 @@ export class NtlmManager implements INtlmManager {
     this._debug = debug;
   }
 
-  ntlmHandshake(ctx: IContext, ntlmHostUrl: CompleteUrl, context: IConnectionContext, callback: (error?: NodeJS.ErrnoException) => void) {
+  ntlmHandshake(ctx: IContext, ntlmHostUrl: CompleteUrl, context: IConnectionContext, callback: (error?: NodeJS.ErrnoException, res?: http.IncomingMessage) => void) {
     let fullUrl = ntlmHostUrl.href + ntlmHostUrl.path;
     context.setState(ntlmHostUrl, NtlmStateEnum.NotAuthenticated);
     let config = this._configStore.get(ntlmHostUrl);
@@ -63,11 +63,33 @@ export class NtlmManager implements INtlmManager {
         return callback(new Error('Cannot parse NTLM message type 2 from host ' + fullUrl));
       }
       let type3msg = ntlm.createType3Message(type2msg, config.username, config.password, config.workstation, config.domain);
-      ctx.proxyToServerRequestOptions.headers['authorization'] = type3msg;
+      let type3requestOptions: https.RequestOptions = {
+        method: ctx.proxyToServerRequestOptions.method,
+        path: ctx.proxyToServerRequestOptions.path,
+        host: ctx.proxyToServerRequestOptions.host,
+        port: ctx.proxyToServerRequestOptions.port as unknown as string,
+        agent: ctx.proxyToServerRequestOptions.agent,
+        headers: ctx.proxyToServerRequestOptions.headers
+      };
+      if (type3requestOptions.headers) { // Always true, silent the compiler
+        type3requestOptions.headers['authorization'] = type3msg;
+      }
+      let type3req = proto.request(type3requestOptions, (res) => {
+        res.pause(); // Finalize the response so we can reuse the socket
+        this.ntlmHandshakeResponse(res, ntlmHostUrl, context, (err) => {
+          return callback(err, res);
+        });
+      });
+      type3req.on('error', (err) => {
+        this._debug.log('Error while sending NTLM message type 3:', err);
+        context.resetState(ntlmHostUrl);
+        return callback(err);
+      });
       this._debug.log('Sending NTLM message type 3 with initial client request');
       this.debugHeader(type3msg, true);
       context.setState(ntlmHostUrl, NtlmStateEnum.Type3Sent);
-      return callback();
+      type3req.write(context.getRequestBody());
+      type3req.end();
     });
     type1req.on('error', (err) => {
       this._debug.log('Error while sending NTLM message type 1:', err);
@@ -80,14 +102,14 @@ export class NtlmManager implements INtlmManager {
     type1req.end();
   }
 
-  ntlmHandshakeResponse(ctx: IContext, ntlmHostUrl: CompleteUrl, context: IConnectionContext, callback: (error?: NodeJS.ErrnoException) => void) {
+  ntlmHandshakeResponse(res: http.IncomingMessage, ntlmHostUrl: CompleteUrl, context: IConnectionContext, callback: (error?: NodeJS.ErrnoException) => void) {
     let authState = context.getState(ntlmHostUrl);
     if (authState === NtlmStateEnum.NotAuthenticated) {
       // NTLM auth failed (host may not support NTLM), just pass it through
       return callback();
     }
     if (authState === NtlmStateEnum.Type3Sent) {
-      if (ctx.serverToProxyResponse.statusCode === 401) {
+      if (res.statusCode === 401) {
         this._debug.log('NTLM authentication failed, invalid credentials.');
         context.resetState(ntlmHostUrl);
         return callback();
@@ -103,7 +125,19 @@ export class NtlmManager implements INtlmManager {
     return callback();
   }
 
-  private canHandleNtlmAuthentication(res: http.IncomingMessage): boolean {
+  acceptsNtlmAuthentication(res: http.IncomingMessage): boolean {
+    if (res && res.statusCode === 401) {
+      // Ensure that we're talking NTLM here
+      const wwwAuthenticate = res.headers['www-authenticate'];
+      if (wwwAuthenticate &&
+          wwwAuthenticate.toUpperCase().split(', ').indexOf('NTLM') !== -1) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  canHandleNtlmAuthentication(res: http.IncomingMessage): boolean {
     if (res && res.statusCode === 401) {
       // Ensure that we're talking NTLM here
       const wwwAuthenticate = res.headers['www-authenticate'];

--- a/test/proxy/express.server.ts
+++ b/test/proxy/express.server.ts
@@ -30,6 +30,7 @@ export class ExpressServer {
 
   private lastRequestHeaders: http.IncomingHttpHeaders;
   private sendNtlmType2Header: string = null;
+  private sendWwwAuthHeader: string = null;
 
   constructor() {
     this.initExpress(this.appNoAuth, false);
@@ -70,6 +71,10 @@ export class ExpressServer {
       if (this.sendNtlmType2Header !== null) {
         res.setHeader('www-authenticate', 'NTLM ' + this.sendNtlmType2Header );
         res.sendStatus(401);
+      } else if (this.sendWwwAuthHeader != null) {
+        res.setHeader('www-authenticate', this.sendWwwAuthHeader);
+        res.sendStatus(401);
+        this.sendWwwAuthHeader = null;
       } else {
         res.status(200).send(JSON.stringify(body));
       }
@@ -86,6 +91,10 @@ export class ExpressServer {
       if (this.sendNtlmType2Header !== null) {
         res.setHeader('www-authenticate', 'NTLM ' + this.sendNtlmType2Header );
         res.sendStatus(401);
+      } else if (this.sendWwwAuthHeader != null) {
+        res.setHeader('www-authenticate', this.sendWwwAuthHeader);
+        res.sendStatus(401);
+        this.sendWwwAuthHeader = null;
       } else {
         res.status(200).send(JSON.stringify(req.body));
       }
@@ -102,6 +111,10 @@ export class ExpressServer {
       if (this.sendNtlmType2Header !== null) {
         res.setHeader('www-authenticate', 'NTLM ' + this.sendNtlmType2Header );
         res.sendStatus(401);
+      } else if (this.sendWwwAuthHeader != null) {
+        res.setHeader('www-authenticate', this.sendWwwAuthHeader);
+        res.sendStatus(401);
+        this.sendWwwAuthHeader = null;
       } else {
         res.status(200).send(req.body);
       }
@@ -118,6 +131,10 @@ export class ExpressServer {
       if (this.sendNtlmType2Header !== null) {
         res.setHeader('www-authenticate', 'NTLM ' + this.sendNtlmType2Header );
         res.sendStatus(401);
+      } else if (this.sendWwwAuthHeader != null) {
+        res.setHeader('www-authenticate', this.sendWwwAuthHeader);
+        res.sendStatus(401);
+        this.sendWwwAuthHeader = null;
       } else {
         res.status(200).send(req.body);
       }
@@ -330,6 +347,14 @@ export class ExpressServer {
 
   sendNtlmType2(fakeHeader: string) {
     this.sendNtlmType2Header = fakeHeader;
+  }
+
+  sendWwwAuthOnce(fakeHeader: string) {
+    this.sendWwwAuthHeader = fakeHeader;
+  }
+
+  restartNtlm() {
+    this.appNtlmAuth.use(ntlm({}));
   }
 }
 

--- a/test/proxy/http.upstream.proxy.spec.ts
+++ b/test/proxy/http.upstream.proxy.spec.ts
@@ -81,7 +81,7 @@ describe('Proxy for HTTP host with NTLM and upstream proxy', function() {
     let res = await ProxyFacade.sendNtlmConfig(configApiUrl, ntlmHostConfig);
     expect(res.status, 'ntlm-config should return 200').to.be.equal(200);
     res = await ProxyFacade.sendRemoteRequest(ntlmProxyUrl, httpUrl, 'GET', '/get', null);
-    expect(upstreamProxyReqCount, 'should be two requests due to handshake').to.be.equal(2);
+    expect(upstreamProxyReqCount, 'should be three requests due to handshake').to.be.equal(3);
     expect(res.status, 'remote request should return 200').to.be.equal(200);
     let resBody = res.data as any;
     expect(resBody.message).to.be.equal('Expecting larger payload on GET');
@@ -101,7 +101,7 @@ describe('Proxy for HTTP host with NTLM and upstream proxy', function() {
     let res = await ProxyFacade.sendNtlmConfig(configApiUrl, ntlmHostConfig);
     expect(res.status, 'ntlm-config should return 200').to.be.equal(200);
     res = await ProxyFacade.sendRemoteRequest(ntlmProxyUrl, httpUrl, 'POST', '/post', body);
-    expect(upstreamProxyReqCount, 'should be two requests due to handshake').to.be.equal(2);
+    expect(upstreamProxyReqCount, 'should be three requests due to handshake').to.be.equal(3);
     expect(res.status, 'remote request should return 200').to.be.equal(200);
     let resBody = res.data as any;
     expect(resBody.ntlmHost).to.be.equal(body.ntlmHost);
@@ -124,7 +124,7 @@ describe('Proxy for HTTP host with NTLM and upstream proxy', function() {
     let res = await ProxyFacade.sendNtlmConfig(configApiUrl, ntlmHostConfig);
     expect(res.status, 'ntlm-config should return 200').to.be.equal(200);
     res = await ProxyFacade.sendRemoteRequest(ntlmProxyUrl, httpUrl, 'PUT', '/put', body);
-    expect(upstreamProxyReqCount, 'should be two requests due to handshake').to.be.equal(2);
+    expect(upstreamProxyReqCount, 'should be three requests due to handshake').to.be.equal(3);
     expect(res.status, 'remote request should return 200').to.be.equal(200);
     let resBody = res.data as any;
     expect(resBody.ntlmHost).to.be.equal(body.ntlmHost);
@@ -147,7 +147,7 @@ describe('Proxy for HTTP host with NTLM and upstream proxy', function() {
     let res = await ProxyFacade.sendNtlmConfig(configApiUrl, ntlmHostConfig);
     expect(res.status, 'ntlm-config should return 200').to.be.equal(200);
     res = await ProxyFacade.sendRemoteRequest(ntlmProxyUrl, httpUrl, 'DELETE', '/delete', body);
-    expect(upstreamProxyReqCount, 'should be two requests due to handshake').to.be.equal(2);
+    expect(upstreamProxyReqCount, 'should be three requests due to handshake').to.be.equal(3);
     expect(res.status, 'remote request should return 200').to.be.equal(200);
     let resBody = res.data as any;
     expect(resBody.ntlmHost).to.be.equal(body.ntlmHost);

--- a/test/proxy/https.upstream.proxy.spec.ts
+++ b/test/proxy/https.upstream.proxy.spec.ts
@@ -79,7 +79,7 @@ describe('Proxy for HTTPS host with NTLM and upstream proxy', function() {
     let res = await ProxyFacade.sendNtlmConfig(configApiUrl, ntlmHostConfig);
     expect(res.status, 'ntlm-config should return 200').to.be.equal(200);
     res = await ProxyFacade.sendRemoteRequest(ntlmProxyUrl, httpsUrl, 'GET', '/get', null, proxyFacade.mitmCaCert);
-    expect(upstreamProxyReqCount, 'should be two requests due to handshake').to.be.equal(2);
+    expect(upstreamProxyReqCount, 'should be three requests due to handshake').to.be.equal(3);
     expect(res.status, 'remote request should return 200').to.be.equal(200);
     let resBody = res.data as any;
     expect(resBody.message).to.be.equal('Expecting larger payload on GET');
@@ -100,7 +100,7 @@ describe('Proxy for HTTPS host with NTLM and upstream proxy', function() {
     let res = await ProxyFacade.sendNtlmConfig(configApiUrl, ntlmHostConfig);
     expect(res.status, 'ntlm-config should return 200').to.be.equal(200);
     res = await ProxyFacade.sendRemoteRequest(ntlmProxyUrl, httpsUrl, 'POST', '/post', body, proxyFacade.mitmCaCert);
-    expect(upstreamProxyReqCount, 'should be two requests due to handshake').to.be.equal(2);
+    expect(upstreamProxyReqCount, 'should be three requests due to handshake').to.be.equal(3);
     expect(res.status, 'remote request should return 200').to.be.equal(200);
     let resBody = res.data as any;
     expect(resBody.ntlmHost).to.be.equal(body.ntlmHost);
@@ -124,7 +124,7 @@ describe('Proxy for HTTPS host with NTLM and upstream proxy', function() {
     let res = await ProxyFacade.sendNtlmConfig(configApiUrl, ntlmHostConfig);
     expect(res.status, 'ntlm-config should return 200').to.be.equal(200);
     res = await ProxyFacade.sendRemoteRequest(ntlmProxyUrl, httpsUrl, 'PUT', '/put', body, proxyFacade.mitmCaCert);
-    expect(upstreamProxyReqCount, 'should be two requests due to handshake').to.be.equal(2);
+    expect(upstreamProxyReqCount, 'should be three requests due to handshake').to.be.equal(3);
     expect(res.status, 'remote request should return 200').to.be.equal(200);
     let resBody = res.data as any;
     expect(resBody.ntlmHost).to.be.equal(body.ntlmHost);
@@ -148,7 +148,7 @@ describe('Proxy for HTTPS host with NTLM and upstream proxy', function() {
     let res = await ProxyFacade.sendNtlmConfig(configApiUrl, ntlmHostConfig);
     expect(res.status, 'ntlm-config should return 200').to.be.equal(200);
     res = await ProxyFacade.sendRemoteRequest(ntlmProxyUrl, httpsUrl, 'DELETE', '/delete', body, proxyFacade.mitmCaCert);
-    expect(upstreamProxyReqCount, 'should be two requests due to handshake').to.be.equal(2);
+    expect(upstreamProxyReqCount, 'should be three requests due to handshake').to.be.equal(3);
     expect(res.status, 'remote request should return 200').to.be.equal(200);
     let resBody = res.data as any;
     expect(resBody.ntlmHost).to.be.equal(body.ntlmHost);


### PR DESCRIPTION
* Fix #62, #64 and #65: Implemented full NTLM handshake. Authentication is only initiated when the server sends a 401 challenge response which indicates that NTLM authentication is supported. This should resolve the issues seen by some users for:
  * CORS preflight messages
  * when the server repeats the challenge after first authentication
  * subsites within a host that does not use NTLM authentication.