### PR TITLE
v2.0.1 - Node module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,18 @@
 # Changelog
 
-## 2.0.0-beta.6 - released 2019-10-11
+## 2.0.0 - released 2019-10-11
+
+* Fixed #73: Single sign on is here! This is a big improvement in usability and security (no password required) for use cases where authentication only needs a single user, and that user is the same as the account running the tests. Naturally this only works on Windows OSs test clients.
+
+## 2.0.0-beta.6 - released 2019-10-10
 
 * Fix: Disable OS validation in browser context
 
-## 2.0.0-beta.5 - released 2019-10-11
+## 2.0.0-beta.5 - released 2019-10-10
 
 * Fix: Missing require for ntlmSso command
 
-## 2.0.0-beta.4 - released 2019-10-11
+## 2.0.0-beta.4 - released 2019-10-10
 
 * Validation of SSO configuration
 * Updated to latest win-sso to handle empty targetHost

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 2.0.0 - released 2019-10-11
+## 2.0.1 - released 2019-10-14
+
+* Fixed #75: Node module API available. The ntlm-proxy and cypress can now be started as a function call in node, see the README for example code.
+
+## 2.0.0 - released 2019-10-12
 
 * Fixed #73: Single sign on is here! This is a big improvement in usability and security (no password required) for use cases where authentication only needs a single user, and that user is the same as the account running the tests. Naturally this only works on Windows OSs test clients.
 

--- a/README.md
+++ b/README.md
@@ -352,6 +352,21 @@ If the recommended startup scripts from above are used, the ntlm-proxy will be t
 
 To write also the NTLM headers sent and received by ntlm-proxy, set the environment variable `DEBUG_NTLM_HEADERS=1`. If you use this, take some care with the logs since access to the NTLM headers is an attack vector for the account, especially if you are using NTLMv1.
 
+## Node module API
+
+This plugin can also be called as a Node module. It mimics the behavior of the [run method in Cypress module API](https://docs.cypress.io/guides/guides/module-api.html#cypress-run) - accepting the same arguments, passing them on to Cypress and returning the same value. It will automatically start the ntlm-proxy before calling `cypress.run()`, and it will shut down the ntlm-proxy after the tests have finished.
+
+### Example
+
+```javascript
+const cypressNtlmAuth = require('cypress-ntlm-auth');
+cypressNtlmAuth.run({
+  spec: './cypress/integration/test.spec.js'
+})
+.then(result => console.log(result))
+.catch(err => console.log(err));
+```
+
 ## Notes
 
 ### ntlm-proxy process
@@ -382,7 +397,6 @@ If you are unable to resolve the certificate issues you can use the standard Nod
 
 ## Planned work
 
-* More real-world testing against Windows servers
 * Support custom http.Agent / https.Agent configuration
 * Configuration option to disable self-signed certificates even for localhost
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cypress-ntlm-auth",
   "version": "2.0.0",
   "description": "NTLM authentication plugin for Cypress",
-  "main": "dist/proxy/main.js",
+  "main": "dist/index.js",
   "scripts": {
     "proxy": "src/launchers/ntlm.proxy.main.js",
     "launch": "src/launchers/cypress.ntlm.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ const container = new DependencyInjection();
 let cypressNtlm = container.get<ICypressNtlm>(TYPES.ICypressNtlm);
 let proxyMain = container.get<IMain>(TYPES.IMain);
 
-export async function run(options): Promise<any> {
+export async function run(options: any): Promise<any> {
   return new Promise((resolve, reject) => {
     if (cypressNtlm.checkCypressIsInstalled() === false) {
       throw new Error('cypress-ntlm-auth requires Cypress to be installed.\n');
@@ -24,10 +24,10 @@ export async function run(options): Promise<any> {
 
         // Start up Cypress and let it parse any options
         cypress.run(options)
-        .then(result => {
+        .then((result: any) => {
           proxyMain.stop().then(() => resolve(result));
         })
-        .catch(err => {
+        .catch((err: any) => {
           proxyMain.stop().then(() => reject(err));
         });
       });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,38 @@
+import { DependencyInjection } from './proxy/dependency.injection';
+import { TYPES } from './proxy/dependency.injection.types';
+import { IMain } from './proxy/interfaces/i.main';
+import { ICypressNtlm } from './util/interfaces/i.cypress.ntlm';
+
+const cypress = require('cypress');
+
+const container = new DependencyInjection();
+let cypressNtlm = container.get<ICypressNtlm>(TYPES.ICypressNtlm);
+let proxyMain = container.get<IMain>(TYPES.IMain);
+
+export async function run(options): Promise<any> {
+  return new Promise((resolve, reject) => {
+    if (cypressNtlm.checkCypressIsInstalled() === false) {
+      throw new Error('cypress-ntlm-auth requires Cypress to be installed.\n');
+    }
+
+    proxyMain.run(false, process.env.HTTP_PROXY, process.env.HTTPS_PROXY, process.env.NO_PROXY)
+    .then(() => {
+      cypressNtlm.checkProxyIsRunning(5000, 200)
+      .then((portsFile) => {
+        process.env.HTTP_PROXY = portsFile.ntlmProxyUrl;
+        process.env.NO_PROXY = '';
+
+        // Start up Cypress and let it parse any options
+        cypress.run(options)
+        .then(result => {
+          proxyMain.stop().then(() => resolve(result));
+        })
+        .catch(err => {
+          proxyMain.stop().then(() => reject(err));
+        });
+      });
+    });
+  });
+}
+
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,19 +2,21 @@ import { DependencyInjection } from './proxy/dependency.injection';
 import { TYPES } from './proxy/dependency.injection.types';
 import { IMain } from './proxy/interfaces/i.main';
 import { ICypressNtlm } from './util/interfaces/i.cypress.ntlm';
-
-const cypress = require('cypress');
+import { IDebugLogger } from './util/interfaces/i.debug.logger';
+import nodeCleanup from 'node-cleanup';
 
 const container = new DependencyInjection();
 let cypressNtlm = container.get<ICypressNtlm>(TYPES.ICypressNtlm);
 let proxyMain = container.get<IMain>(TYPES.IMain);
+let debug = container.get<IDebugLogger>(TYPES.IDebugLogger);
 
 export async function run(options: any): Promise<any> {
   return new Promise((resolve, reject) => {
     if (cypressNtlm.checkCypressIsInstalled() === false) {
-      throw new Error('cypress-ntlm-auth requires Cypress to be installed.\n');
+      throw new Error('cypress-ntlm-auth requires Cypress to be installed.');
     }
 
+    debug.log('Starting ntlm-proxy...');
     proxyMain.run(false, process.env.HTTP_PROXY, process.env.HTTPS_PROXY, process.env.NO_PROXY)
     .then(() => {
       cypressNtlm.checkProxyIsRunning(5000, 200)
@@ -22,12 +24,16 @@ export async function run(options: any): Promise<any> {
         process.env.HTTP_PROXY = portsFile.ntlmProxyUrl;
         process.env.NO_PROXY = '';
 
+        debug.log('ntlm-proxy started, running tests through Cypress...');
         // Start up Cypress and let it parse any options
+        const cypress = require('cypress');
         cypress.run(options)
         .then((result: any) => {
+          debug.log('Tests finished, stopping ntlm-proxy...');
           proxyMain.stop().then(() => resolve(result));
         })
         .catch((err: any) => {
+          debug.log('Test exception, stopping ntlm-proxy...');
           proxyMain.stop().then(() => reject(err));
         });
       });
@@ -35,4 +41,26 @@ export async function run(options: any): Promise<any> {
   });
 }
 
+// Unfortunately we can only catch these signals on Mac/Linux,
+// Windows gets a hard exit => the portsFile is left behind,
+// but will be replaced on next start
+nodeCleanup((exitCode, signal) => {
+  if (exitCode) {
+    debug.log('Detected process exit with code', exitCode);
+    // On a non-signal exit, we cannot postpone the process termination.
+    // We try to cleanup but cannot be sure that the ports file was deleted.
+    proxyMain.stop();
+  }
+  if (signal) {
+    debug.log('Detected termination signal', signal);
+    // On signal exit, we postpone the process termination by returning false,
+    // to ensure that cleanup has completed.
+    (async () => {
+      await proxyMain.stop();
+      process.kill(process.pid, signal);
+    })();
+    nodeCleanup.uninstall(); // don't call cleanup handler again
+    return false;
+  }
+});
 

--- a/test/node-module/index.spec.ts
+++ b/test/node-module/index.spec.ts
@@ -1,0 +1,20 @@
+const cypressNtlmAuth = require('../../src/index');
+
+import chai from 'chai';
+
+describe('Execute as node module', function() {
+  describe('run', function () {
+    // Only this negative test is possible here. Positive tests are
+    it('should fail since cypress isn\'t installed', async function() {
+      // Arrange
+      let cypressOptions = {
+        baseUrl: 'http://localhost:5000',
+        video: false,
+        spec: './cypress/integration/config.spec.js'
+      };
+
+      // Act
+      await chai.expect(cypressNtlmAuth.run(cypressOptions)).to.be.rejectedWith('cypress-ntlm-auth requires Cypress to be installed.');
+    });
+  });
+});


### PR DESCRIPTION
* Fixed #75: Node module API available. The ntlm-proxy and cypress can now be started as a function call in node, see the README for example code.
