### PR TITLE
Release 2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.2 - released 2019-10-29
+
+* Fixed #81: Cypress 3.5.0 now supported also for localhost sites.
+* Improved responses on failed handshakes
+* Minor improvements for NodeJS 13 compatibility
+
 ## 2.0.1 - released 2019-10-14
 
 * Fixed #75: Node module API available. The ntlm-proxy and cypress can now be started as a function call in node, see the README for example code.

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ export async function run(options: any): Promise<any> {
       cypressNtlm.checkProxyIsRunning(5000, 200)
       .then((portsFile) => {
         process.env.HTTP_PROXY = portsFile.ntlmProxyUrl;
-        process.env.NO_PROXY = '';
+        process.env.NO_PROXY = '<-loopback>';
 
         debug.log('ntlm-proxy started, running tests through Cypress...');
         // Start up Cypress and let it parse any options

--- a/src/launchers/cypress.ntlm.ts
+++ b/src/launchers/cypress.ntlm.ts
@@ -15,7 +15,7 @@ if (cypressNtlm.checkCypressIsInstalled() === false) {
 cypressNtlm.checkProxyIsRunning(5000, 200)
 .then((portsFile) => {
   process.env.HTTP_PROXY = portsFile.ntlmProxyUrl;
-  process.env.NO_PROXY = '';
+  process.env.NO_PROXY = '<-loopback>';
 
   // Start up Cypress and let it parse any command line arguments
   require('cypress/lib/cli').init();

--- a/src/proxy/connection.context.manager.ts
+++ b/src/proxy/connection.context.manager.ts
@@ -43,21 +43,20 @@ export class ConnectionContextManager implements IConnectionContextManager {
     return clientSocket.remoteAddress + ':' + clientSocket.remotePort;
   }
 
-  createConnectionContext(clientSocket: Socket, isSSL: boolean, targetHost: CompleteUrl, useNtlm: boolean, useSso: boolean): IConnectionContext {
+  createConnectionContext(clientSocket: Socket, isSSL: boolean, targetHost: CompleteUrl,  useSso: boolean): IConnectionContext {
     let clientAddress = this.getClientAddress(clientSocket);
     if (clientAddress in this._connectionContexts) {
       return this._connectionContexts[clientAddress];
     }
 
-    let agent = this.getAgent(isSSL, targetHost, useNtlm);
+    let agent = this.getAgent(isSSL, targetHost);
     agent._cyAgentId = this._agentCount++;
     let context = new this.ConnectionContext();
     context.agent = agent;
     context.useSso = useSso;
     this._connectionContexts[clientAddress] = context;
     clientSocket.on('close', () => this.removeAgent('close', clientAddress));
-    this._debug.log('Created ' + (useNtlm ? 'NTLM ready' : 'non-NTLM') +
-      ' agent for client ' + clientAddress + ' to target ' + targetHost.href);
+    this._debug.log('Created agent for client ' + clientAddress + ' to target ' + targetHost.href);
     return context;
   }
 
@@ -76,15 +75,12 @@ export class ConnectionContextManager implements IConnectionContextManager {
     return true;
   }
 
-  getAgent(isSSL: boolean, targetHost: CompleteUrl, useNtlm: boolean) {
+  getAgent(isSSL: boolean, targetHost: CompleteUrl) {
     let agentOptions: https.AgentOptions = {
-      keepAlive: useNtlm,
+      keepAlive: true,
+      maxSockets: 1, // Only one connection per peer -> 1:1 match between inbound and outbound socket
       rejectUnauthorized: this.nodeTlsRejectUnauthorized() && !targetHost.isLocalhost // Allow self-signed certificates if target is on localhost
     };
-    if (useNtlm) {
-      // Only one connection per peer -> 1:1 match between inbound and outbound socket
-      agentOptions.maxSockets = 1;
-    }
     let useUpstreamProxy = this._upstreamProxyManager
       .setUpstreamProxyConfig(targetHost, isSSL, agentOptions);
     let agent;

--- a/src/proxy/interfaces/i.connection.context.manager.ts
+++ b/src/proxy/interfaces/i.connection.context.manager.ts
@@ -3,9 +3,9 @@ import { CompleteUrl } from '../../models/complete.url.model';
 import { IConnectionContext } from './i.connection.context';
 
 export interface IConnectionContextManager {
-  createConnectionContext(clientSocket: Socket, isSSL: boolean, targetHost: CompleteUrl, useNtlm: boolean, useSso: boolean): IConnectionContext;
+  createConnectionContext(clientSocket: Socket, isSSL: boolean, targetHost: CompleteUrl, useSso: boolean): IConnectionContext;
   getConnectionContextFromClientSocket(clientSocket: Socket): IConnectionContext | undefined;
-  getAgent(isSSL: boolean, targetHost: CompleteUrl, useNtlm: boolean): any;
+  getAgent(isSSL: boolean, targetHost: CompleteUrl): any;
   getUntrackedAgent(targetHost: CompleteUrl): any;
   clearAuthentication(ntlmHostUrl: CompleteUrl): void;
   removeAllConnectionContexts(event: string): void;


### PR DESCRIPTION
* Fixed #81: Cypress 3.5.0 now supported also for localhost sites.
* Improved responses on failed handshakes
* Minor improvements for NodeJS 13 compatibility