### PR TITLE
Reuse client sockets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.4 - released 2019-11-28
+
+* Unit tests for fix of #88
+* Handled the case when server prompts for reauthentication after a host reconfiguration
+* Fixed #86: Increased startup wait time for ntlm-proxy to 15 seconds
+
 ## 2.0.4-beta.1 - released 2019-11-27
 
 * Handle reuse of client sockets for new targets to fix #88.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.4-beta.1 - released 2019-11-27
+
+* Handle reuse of client sockets for new targets to fix #88.
+
 ## 2.0.3 - released 2019-11-13
 
 * Attempt to fix #80 without a forced quit. All tunnels established for HTTPS passthrough are now indexed and closed on reset or quit.

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ cy.ntlm(ntlmHost, username, password, [domain, [workstation, [ntlmVersion]]]);
 * workstation (optional): the workstation name of the client. Default value: `os.hostname()`;
 * ntlmVersion (optional): the version of the NTLM protocol to use. Valid values are 1 and 2. Default value: 2. This can be useful for legacy hosts that don't support NTLMv2, or for certain scenarios where the NTLMv2 handshake fails (the plugin does not implement all features of NTLMv2 yet).
 
-The ntlm command may be called multiple times to setup multiple ntlmHosts, also with different credentials. If the ntlm command is called with the same ntlmHost again, it overwrites the credentials for that ntlmHost.
+The ntlm command may be called multiple times to setup multiple ntlmHosts, also with different credentials. If the ntlm command is called with the same ntlmHost again, it overwrites the credentials for that ntlmHost. Existing connections are not terminated, but if the server requests reauthentication the new credentials will be used.
 
 Configuration set with the ntlm command persists until it is reset (see ntlmReset command) or when the proxy is terminated. Take note that it *is not cleared when the current spec file is finished*.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-ntlm-auth",
-  "version": "2.0.3",
+  "version": "2.0.4-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-ntlm-auth",
-  "version": "2.0.3",
+  "version": "2.0.4-beta.1",
   "description": "NTLM authentication plugin for Cypress",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ export async function run(options: any): Promise<any> {
     debug.log('Starting ntlm-proxy...');
     proxyMain.run(false, process.env.HTTP_PROXY, process.env.HTTPS_PROXY, process.env.NO_PROXY)
     .then(() => {
-      cypressNtlm.checkProxyIsRunning(5000, 200)
+      cypressNtlm.checkProxyIsRunning(15000, 200)
       .then((portsFile) => {
         process.env.HTTP_PROXY = portsFile.ntlmProxyUrl;
         process.env.NO_PROXY = '<-loopback>';

--- a/src/launchers/cypress.ntlm.ts
+++ b/src/launchers/cypress.ntlm.ts
@@ -12,7 +12,7 @@ if (cypressNtlm.checkCypressIsInstalled() === false) {
   process.exit(1);
 }
 
-cypressNtlm.checkProxyIsRunning(5000, 200)
+cypressNtlm.checkProxyIsRunning(15000, 200)
 .then((portsFile) => {
   process.env.HTTP_PROXY = portsFile.ntlmProxyUrl;
   process.env.NO_PROXY = '<-loopback>';

--- a/src/proxy/connection.context.manager.ts
+++ b/src/proxy/connection.context.manager.ts
@@ -40,9 +40,6 @@ export class ConnectionContextManager implements IConnectionContextManager {
     this._configController = configController;
     this.ConnectionContext = connectionContext;
     this._debug = debug;
-
-    this._configController.configApiEvent.addListener('configUpdate',
-      (ntlmHostUrl: CompleteUrl) => this.clearAuthentication(ntlmHostUrl));
   }
 
   private getClientAddress(clientSocket: Socket): string {
@@ -113,14 +110,6 @@ export class ConnectionContextManager implements IConnectionContextManager {
     return agent;
   }
 
-  clearAuthentication(ntlmHostUrl: CompleteUrl) {
-    for (let property in this._connectionContexts) {
-      if (this._connectionContexts.hasOwnProperty(property)) {
-        this._connectionContexts[property].resetState(ntlmHostUrl);
-      }
-    }
-  }
-
   removeAllConnectionContexts(event: string) {
     for (let property in this._connectionContexts) {
       if (this._connectionContexts.hasOwnProperty(property)) {
@@ -138,10 +127,8 @@ export class ConnectionContextManager implements IConnectionContextManager {
       if (this._connectionContexts[clientAddress].agent.destroy) {
         this._connectionContexts[clientAddress].agent.destroy(); // Destroys any sockets to servers
       }
-    delete this._connectionContexts[clientAddress];
+      delete this._connectionContexts[clientAddress];
       this._debug.log('Removed agent for ' + clientAddress + ' due to socket.' + event);
-    } else {
-      this._debug.log('RemoveAgent called for ' + clientAddress + ' due to socket.' + event + ', but agent does not exist');
     }
   }
 

--- a/src/proxy/connection.context.manager.ts
+++ b/src/proxy/connection.context.manager.ts
@@ -58,6 +58,7 @@ export class ConnectionContextManager implements IConnectionContextManager {
     let agent = this.getAgent(isSSL, targetHost);
     agent._cyAgentId = this._agentCount++;
     let context = new this.ConnectionContext();
+    context.clientAddress = clientAddress;
     context.agent = agent;
     context.useSso = useSso;
     this._connectionContexts[clientAddress] = context;

--- a/src/proxy/connection.context.ts
+++ b/src/proxy/connection.context.ts
@@ -42,13 +42,6 @@ export class ConnectionContext implements IConnectionContext {
     this._clientAddress = clientAddress;
   }
 
-  isAuthenticated(ntlmHostUrl: CompleteUrl): boolean {
-    let auth = (this._ntlmHost !== undefined &&
-      this._ntlmHost.href === ntlmHostUrl.href &&
-      this._ntlmState === NtlmStateEnum.Authenticated);
-    return auth;
-  }
-
   isNewOrAuthenticated(ntlmHostUrl: CompleteUrl): boolean {
     let auth = this._ntlmHost === undefined ||
       (this._ntlmHost !== undefined &&
@@ -71,12 +64,6 @@ export class ConnectionContext implements IConnectionContext {
   setState(ntlmHostUrl: CompleteUrl, authState: NtlmStateEnum) {
     this._ntlmHost = ntlmHostUrl;
     this._ntlmState = authState;
-  }
-
-  resetState(ntlmHostUrl: CompleteUrl) {
-    if (this._ntlmHost !== undefined && this._ntlmHost.href === ntlmHostUrl.href) {
-      this._ntlmState = NtlmStateEnum.NotAuthenticated;
-    }
   }
 
   clearRequestBody() {

--- a/src/proxy/connection.context.ts
+++ b/src/proxy/connection.context.ts
@@ -12,6 +12,7 @@ export class ConnectionContext implements IConnectionContext {
   private _requestBody = Buffer.alloc(0);
   private _useSso = false;
   private _peerCert?: PeerCertificate;
+  private _clientAddress = '';
 
   get agent(): any {
     return this._agent;
@@ -34,6 +35,13 @@ export class ConnectionContext implements IConnectionContext {
     this._peerCert = peerCert;
   }
 
+  get clientAddress(): string {
+    return this._clientAddress;
+  }
+  set clientAddress(clientAddress: string) {
+    this._clientAddress = clientAddress;
+  }
+
   isAuthenticated(ntlmHostUrl: CompleteUrl): boolean {
     let auth = (this._ntlmHost !== undefined &&
       this._ntlmHost.href === ntlmHostUrl.href &&
@@ -47,6 +55,10 @@ export class ConnectionContext implements IConnectionContext {
        this._ntlmHost.href === ntlmHostUrl.href &&
        this._ntlmState === NtlmStateEnum.Authenticated);
     return auth;
+  }
+
+  matchHostOrNew(ntlmHostUrl: CompleteUrl): boolean {
+    return (this._ntlmHost === undefined || this._ntlmHost.href === ntlmHostUrl.href);
   }
 
   getState(ntlmHostUrl: CompleteUrl): NtlmStateEnum {

--- a/src/proxy/interfaces/i.connection.context.manager.ts
+++ b/src/proxy/interfaces/i.connection.context.manager.ts
@@ -7,7 +7,6 @@ export interface IConnectionContextManager {
   getConnectionContextFromClientSocket(clientSocket: Socket): IConnectionContext | undefined;
   getAgent(isSSL: boolean, targetHost: CompleteUrl): any;
   getUntrackedAgent(targetHost: CompleteUrl): any;
-  clearAuthentication(ntlmHostUrl: CompleteUrl): void;
   removeAllConnectionContexts(event: string): void;
   removeAgent(event: string, clientAddress: string): void;
   addTunnel(client: Socket, target: Socket): void;

--- a/src/proxy/interfaces/i.connection.context.ts
+++ b/src/proxy/interfaces/i.connection.context.ts
@@ -6,9 +6,11 @@ export interface IConnectionContext {
   agent: any;
   useSso: boolean;
   peerCert: PeerCertificate | undefined;
+  clientAddress: string;
 
   isAuthenticated(ntlmHostUrl: CompleteUrl): boolean;
   isNewOrAuthenticated(ntlmHostUrl: CompleteUrl): boolean;
+  matchHostOrNew(ntlmHostUrl: CompleteUrl): boolean;
   getState(ntlmHostUrl: CompleteUrl): NtlmStateEnum;
   setState(ntlmHostUrl: CompleteUrl, authState: NtlmStateEnum): void;
   resetState(ntlmHostUrl: CompleteUrl): void;

--- a/src/proxy/interfaces/i.connection.context.ts
+++ b/src/proxy/interfaces/i.connection.context.ts
@@ -8,12 +8,10 @@ export interface IConnectionContext {
   peerCert: PeerCertificate | undefined;
   clientAddress: string;
 
-  isAuthenticated(ntlmHostUrl: CompleteUrl): boolean;
   isNewOrAuthenticated(ntlmHostUrl: CompleteUrl): boolean;
   matchHostOrNew(ntlmHostUrl: CompleteUrl): boolean;
   getState(ntlmHostUrl: CompleteUrl): NtlmStateEnum;
   setState(ntlmHostUrl: CompleteUrl, authState: NtlmStateEnum): void;
-  resetState(ntlmHostUrl: CompleteUrl): void;
 
   clearRequestBody(): void;
   addToRequestBody(chunk: Buffer): void;

--- a/src/proxy/ntlm.proxy.mitm.ts
+++ b/src/proxy/ntlm.proxy.mitm.ts
@@ -98,6 +98,11 @@ export class NtlmProxyMitm implements INtlmProxyMitm {
           .getConnectionContextFromClientSocket(ctx.clientToProxyRequest.socket);
       let useSso = self._configStore.useSso(targetHost);
       let useNtlm = useSso || self._configStore.exists(targetHost);
+      if (context && context.matchHostOrNew(targetHost) === false) {
+        self._debug.log('Existing client socket ' + context.clientAddress + ' received request to a different target, remove existing context');
+        self._connectionContextManager.removeAgent('reuse', context.clientAddress);
+        context = undefined;
+      }
       if (!context) {
         context = self._connectionContextManager
             .createConnectionContext(ctx.clientToProxyRequest.socket, ctx.isSSL, targetHost, useSso);


### PR DESCRIPTION
* Handle reuse of client sockets for new targets to fix #88.
* Unit tests for fix of #88
* Handled the case when server prompts for reauthentication after a host reconfiguration
* Fixed #86: Increased startup wait time for ntlm-proxy to 15 seconds
