### PR TITLE
Fix #101 - override unused proxy env variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2.2.1 - released 2020-02-08
 
+- Fix #101 - Override unused proxy environment variables before launching cypress to avoid conflicting configurations.
+
+## 2.2.1 - released 2020-02-08
+
 - Fix #99 - Update useSso property on each request to improve stability after ntlmReset
 
 ## 2.2.0 - released 2020-02-02

--- a/README.md
+++ b/README.md
@@ -184,9 +184,11 @@ If your network environment enforces proxy usage for internet access (quite like
 - `HTTPS_PROXY` - (optional) The URL to the proxy for accessing external HTTPS resources. Overrides `HTTP_PROXY` for HTTPS resources. Example: `http://proxy.acme.com:8080`
 - `NO_PROXY` - A comma separated list of internal hosts to exclude from proxying. Add the host you are testing, and other local network resources used from the browser when accessing the host you are testing. Note that hosts that are located on the internet (not your intranet) must not be added, they should pass through the upstream proxy.
 
-  Include only the hostname (or IP), not the protocol or port. Wildcards are supported. Example: \*.acme.com
+Include only the hostname (or IP), not the protocol or port. Wildcards are supported. Example: \*.acme.com
 
-  Since the plugin requires traffic to localhost to be excluded from the corporate proxy, the plugin adds `localhost` and `127.0.0.1` to the `NO_PROXY` setting automatically unless they are already there. To disable this behavior (if you require an additional custom proxy), add `<-loopback>` to `NO_PROXY`.
+Since the plugin requires traffic to localhost to be excluded from the corporate proxy, the plugin adds `localhost` and `127.0.0.1` to the `NO_PROXY` setting automatically unless they are already there. To disable this behavior (if you require an additional custom proxy), add `<-loopback>` to `NO_PROXY`.
+
+Note that these environment variables must be specified as uppercase. Lowercase variants will be ignored.
 
 ## Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -332,7 +332,7 @@
     },
     "array-flatten": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "asn1": {
@@ -1554,7 +1554,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "merge-descriptors": {
@@ -1595,7 +1595,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "minipass": {
@@ -1951,7 +1951,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,11 @@ export async function run(options: any): Promise<any> {
         cypressNtlm.checkProxyIsRunning(15000, 200).then(portsFile => {
           process.env.HTTP_PROXY = portsFile.ntlmProxyUrl;
           process.env.NO_PROXY = "<-loopback>";
+          // Clear other potentially existing proxy settings to avoid conflicts with ntlm-proxy
+          delete process.env.HTTPS_PROXY;
+          delete process.env.http_proxy;
+          delete process.env.https_proxy;
+          delete process.env.no_proxy;
 
           debug.log("ntlm-proxy started, running tests through Cypress...");
           // Start up Cypress and let it parse any options

--- a/src/launchers/cypress.ntlm.ts
+++ b/src/launchers/cypress.ntlm.ts
@@ -25,6 +25,11 @@ cypressNtlm
   .then(portsFile => {
     process.env.HTTP_PROXY = portsFile.ntlmProxyUrl;
     process.env.NO_PROXY = "<-loopback>";
+    // Clear other potentially existing proxy settings to avoid conflicts with ntlm-proxy
+    delete process.env.HTTPS_PROXY;
+    delete process.env.http_proxy;
+    delete process.env.https_proxy;
+    delete process.env.no_proxy;
 
     // Start up Cypress and let it parse any command line arguments
     require("cypress/lib/cli").init();


### PR DESCRIPTION
- Fix #101 - Override unused proxy environment variables before launching cypress to avoid conflicting configurations.