### PR TITLE
Improved fix for #101

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.2.3 - released 2020-02-19
+
+- Updated fix #101 - Override additional unused proxy environment variables before launching cypress to avoid conflicting configurations.
+
 ## 2.2.2 - released 2020-02-19
 
 - Fix #101 - Override unused proxy environment variables before launching cypress to avoid conflicting configurations.

--- a/package-lock.json
+++ b/package-lock.json
@@ -332,7 +332,7 @@
     },
     "array-flatten": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "asn1": {
@@ -1554,7 +1554,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "merge-descriptors": {
@@ -1595,7 +1595,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "minipass": {
@@ -1951,7 +1951,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,11 +32,7 @@ export async function run(options: any): Promise<any> {
         cypressNtlm.checkProxyIsRunning(15000, 200).then(portsFile => {
           process.env.HTTP_PROXY = portsFile.ntlmProxyUrl;
           process.env.NO_PROXY = "<-loopback>";
-          // Clear other potentially existing proxy settings to avoid conflicts with ntlm-proxy
-          delete process.env.HTTPS_PROXY;
-          delete process.env.http_proxy;
-          delete process.env.https_proxy;
-          delete process.env.no_proxy;
+          upstreamProxyConfigurator.removeUnusedProxyEnv();
 
           debug.log("ntlm-proxy started, running tests through Cypress...");
           // Start up Cypress and let it parse any options

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ export async function run(options: any): Promise<any> {
       .then(() => {
         cypressNtlm.checkProxyIsRunning(15000, 200).then(portsFile => {
           process.env.HTTP_PROXY = portsFile.ntlmProxyUrl;
+          process.env.HTTPS_PROXY = portsFile.ntlmProxyUrl;
           process.env.NO_PROXY = "<-loopback>";
           upstreamProxyConfigurator.removeUnusedProxyEnv();
 

--- a/src/launchers/cypress.ntlm.ts
+++ b/src/launchers/cypress.ntlm.ts
@@ -24,6 +24,7 @@ cypressNtlm
   .checkProxyIsRunning(15000, 200)
   .then(portsFile => {
     process.env.HTTP_PROXY = portsFile.ntlmProxyUrl;
+    process.env.HTTPS_PROXY = portsFile.ntlmProxyUrl;
     process.env.NO_PROXY = "<-loopback>";
     upstreamProxyConfigurator.removeUnusedProxyEnv();
 

--- a/src/launchers/cypress.ntlm.ts
+++ b/src/launchers/cypress.ntlm.ts
@@ -25,11 +25,7 @@ cypressNtlm
   .then(portsFile => {
     process.env.HTTP_PROXY = portsFile.ntlmProxyUrl;
     process.env.NO_PROXY = "<-loopback>";
-    // Clear other potentially existing proxy settings to avoid conflicts with ntlm-proxy
-    delete process.env.HTTPS_PROXY;
-    delete process.env.http_proxy;
-    delete process.env.https_proxy;
-    delete process.env.no_proxy;
+    upstreamProxyConfigurator.removeUnusedProxyEnv();
 
     // Start up Cypress and let it parse any command line arguments
     require("cypress/lib/cli").init();

--- a/src/util/interfaces/i.upstream.proxy.configurator.ts
+++ b/src/util/interfaces/i.upstream.proxy.configurator.ts
@@ -1,3 +1,4 @@
 export interface IUpstreamProxyConfigurator {
+  removeUnusedProxyEnv(): void;
   processNoProxyLoopback(): void;
 }

--- a/src/util/upstream.proxy.configurator.ts
+++ b/src/util/upstream.proxy.configurator.ts
@@ -16,12 +16,13 @@ export class UpstreamProxyConfigurator implements IUpstreamProxyConfigurator {
 
   removeUnusedProxyEnv() {
     // Clear potentially existing proxy settings to avoid conflicts in cypress proxy config
-    delete process.env.HTTPS_PROXY;
     delete process.env.http_proxy;
     delete process.env.https_proxy;
     delete process.env.no_proxy;
     delete process.env.npm_config_proxy;
     delete process.env.npm_config_https_proxy;
+    delete process.env.NPM_CONFIG_PROXY;
+    delete process.env.NPM_CONFIG_HTTPS_PROXY;
   }
 
   processNoProxyLoopback() {

--- a/src/util/upstream.proxy.configurator.ts
+++ b/src/util/upstream.proxy.configurator.ts
@@ -13,7 +13,17 @@ export class UpstreamProxyConfigurator implements IUpstreamProxyConfigurator {
   constructor(@inject(TYPES.IDebugLogger) debug: IDebugLogger) {
     this._debug = debug;
   }
-  // TODO only add if required
+
+  removeUnusedProxyEnv() {
+    // Clear potentially existing proxy settings to avoid conflicts in cypress proxy config
+    delete process.env.HTTPS_PROXY;
+    delete process.env.http_proxy;
+    delete process.env.https_proxy;
+    delete process.env.no_proxy;
+    delete process.env.npm_config_proxy;
+    delete process.env.npm_config_https_proxy;
+  }
+
   processNoProxyLoopback() {
     if (process.env.HTTP_PROXY || process.env.HTTPS_PROXY) {
       const env_no_proxy = process.env.NO_PROXY?.trim();

--- a/src/util/upstream.proxy.configurator.ts
+++ b/src/util/upstream.proxy.configurator.ts
@@ -2,6 +2,7 @@ import { TYPES } from "../proxy/dependency.injection.types";
 import { inject, injectable } from "inversify";
 import { IDebugLogger } from "./interfaces/i.debug.logger";
 import { IUpstreamProxyConfigurator } from "./interfaces/i.upstream.proxy.configurator";
+import os from "os";
 
 @injectable()
 export class UpstreamProxyConfigurator implements IUpstreamProxyConfigurator {
@@ -16,9 +17,11 @@ export class UpstreamProxyConfigurator implements IUpstreamProxyConfigurator {
 
   removeUnusedProxyEnv() {
     // Clear potentially existing proxy settings to avoid conflicts in cypress proxy config
-    delete process.env.http_proxy;
-    delete process.env.https_proxy;
-    delete process.env.no_proxy;
+    if (os.platform() !== "win32") {
+      delete process.env.http_proxy;
+      delete process.env.https_proxy;
+      delete process.env.no_proxy;
+    }
     delete process.env.npm_config_proxy;
     delete process.env.npm_config_https_proxy;
     delete process.env.NPM_CONFIG_PROXY;

--- a/test/util/upstream.proxy.configurator.spec.ts
+++ b/test/util/upstream.proxy.configurator.spec.ts
@@ -4,6 +4,7 @@ import "mocha";
 import { Substitute, SubstituteOf, Arg } from "@fluffy-spoon/substitute";
 
 import { expect } from "chai";
+import os from "os";
 
 import { IDebugLogger } from "../../src/util/interfaces/i.debug.logger";
 import { DebugLogger } from "../../src/util/debug.logger";
@@ -152,9 +153,15 @@ describe("UpstreamProxyConfigurator", () => {
       process.env.NPM_CONFIG_PROXY = "test";
       process.env.NPM_CONFIG_HTTPS_PROXY = "test";
       upstreamProxyConfigurator.removeUnusedProxyEnv();
-      expect(process.env.http_proxy).to.be.undefined;
-      expect(process.env.https_proxy).to.be.undefined;
-      expect(process.env.no_proxy).to.be.undefined;
+      if (os.platform() !== "win32") {
+        expect(process.env.http_proxy).to.be.undefined;
+        expect(process.env.https_proxy).to.be.undefined;
+        expect(process.env.no_proxy).to.be.undefined;
+      } else {
+        expect(process.env.http_proxy).not.to.be.undefined;
+        expect(process.env.https_proxy).not.to.be.undefined;
+        expect(process.env.no_proxy).not.to.be.undefined;
+      }
       expect(process.env.npm_config_proxy).to.be.undefined;
       expect(process.env.npm_config_https_proxy).to.be.undefined;
       expect(process.env.NPM_CONFIG_PROXY).to.be.undefined;

--- a/test/util/upstream.proxy.configurator.spec.ts
+++ b/test/util/upstream.proxy.configurator.spec.ts
@@ -135,26 +135,30 @@ describe("UpstreamProxyConfigurator", () => {
   describe("removeUnusedProxyEnv", function() {
     it("should not modify HTTP_PROXY or NO_PROXY", function() {
       process.env.HTTP_PROXY = "test";
+      process.env.HTTPS_PROXY = "test2";
       process.env.NO_PROXY = "ello.com";
       upstreamProxyConfigurator.removeUnusedProxyEnv();
       expect(process.env.HTTP_PROXY).to.equal("test");
+      expect(process.env.HTTPS_PROXY).to.equal("test2");
       expect(process.env.NO_PROXY).to.equal("ello.com");
     });
 
-    it("should remove lowercase proxy settings and HTTPS_PROXY", function() {
-      process.env.HTTPS_PROXY = "test";
+    it("should remove lowercase proxy settings", function() {
       process.env.http_proxy = "test";
       process.env.https_proxy = "test";
       process.env.no_proxy = "test";
       process.env.npm_config_proxy = "test";
       process.env.npm_config_https_proxy = "test";
+      process.env.NPM_CONFIG_PROXY = "test";
+      process.env.NPM_CONFIG_HTTPS_PROXY = "test";
       upstreamProxyConfigurator.removeUnusedProxyEnv();
-      expect(process.env.HTTPS_PROXY).to.be.undefined;
       expect(process.env.http_proxy).to.be.undefined;
       expect(process.env.https_proxy).to.be.undefined;
       expect(process.env.no_proxy).to.be.undefined;
       expect(process.env.npm_config_proxy).to.be.undefined;
       expect(process.env.npm_config_https_proxy).to.be.undefined;
+      expect(process.env.NPM_CONFIG_PROXY).to.be.undefined;
+      expect(process.env.NPM_CONFIG_HTTPS_PROXY).to.be.undefined;
     });
   });
 });

--- a/test/util/upstream.proxy.configurator.spec.ts
+++ b/test/util/upstream.proxy.configurator.spec.ts
@@ -29,104 +29,132 @@ describe("UpstreamProxyConfigurator", () => {
     delete process.env.NO_PROXY;
   });
 
-  it("should not modify NO_PROXY when neither HTTP_PROXY or HTTPS_PROXY are set", function() {
-    upstreamProxyConfigurator.processNoProxyLoopback();
-    expect(process.env.NO_PROXY).to.be.undefined;
+  describe("processNoProxyLoopback", function() {
+    it("should not modify NO_PROXY when neither HTTP_PROXY or HTTPS_PROXY are set", function() {
+      upstreamProxyConfigurator.processNoProxyLoopback();
+      expect(process.env.NO_PROXY).to.be.undefined;
+    });
+
+    it("should modify NO_PROXY when HTTP_PROXY is set", function() {
+      process.env.HTTP_PROXY = "test";
+      upstreamProxyConfigurator.processNoProxyLoopback();
+      expect(process.env.NO_PROXY).not.to.be.undefined;
+    });
+
+    it("should modify NO_PROXY when HTTPS_PROXY is set", function() {
+      process.env.HTTPS_PROXY = "test";
+      upstreamProxyConfigurator.processNoProxyLoopback();
+      expect(process.env.NO_PROXY).not.to.be.undefined;
+    });
+
+    it("should add both localhost and 127.0.0.1 to NO_PROXY", function() {
+      process.env.HTTP_PROXY = "test";
+      upstreamProxyConfigurator.processNoProxyLoopback();
+      expect(process.env.NO_PROXY).to.equal("localhost,127.0.0.1");
+    });
+
+    it("should not add localhost to NO_PROXY if already present variant 1", function() {
+      process.env.HTTP_PROXY = "test";
+      process.env.NO_PROXY = "localhost";
+      upstreamProxyConfigurator.processNoProxyLoopback();
+      expect(process.env.NO_PROXY).to.equal("localhost,127.0.0.1");
+    });
+
+    it("should not add localhost to NO_PROXY if already present variant 2", function() {
+      process.env.HTTP_PROXY = "test";
+      process.env.NO_PROXY = " localhost ";
+      upstreamProxyConfigurator.processNoProxyLoopback();
+      expect(process.env.NO_PROXY).to.equal("localhost,127.0.0.1");
+    });
+
+    it("should not add localhost to NO_PROXY if already present variant 3", function() {
+      process.env.HTTP_PROXY = "test";
+      process.env.NO_PROXY = "google.com, localhost , ello.com";
+      upstreamProxyConfigurator.processNoProxyLoopback();
+      expect(process.env.NO_PROXY).to.equal(
+        "google.com,localhost,ello.com,127.0.0.1"
+      );
+    });
+
+    it("should not add localhost to NO_PROXY if already present variant 4", function() {
+      process.env.HTTP_PROXY = "test";
+      process.env.NO_PROXY = "google.com,localhost,ello.com";
+      upstreamProxyConfigurator.processNoProxyLoopback();
+      expect(process.env.NO_PROXY).to.equal(
+        "google.com,localhost,ello.com,127.0.0.1"
+      );
+    });
+
+    it("should not add 127.0.0.1 to NO_PROXY if already present variant 1", function() {
+      process.env.HTTP_PROXY = "test";
+      process.env.NO_PROXY = "127.0.0.1";
+      upstreamProxyConfigurator.processNoProxyLoopback();
+      expect(process.env.NO_PROXY).to.equal("127.0.0.1,localhost");
+    });
+
+    it("should not add 127.0.0.1 to NO_PROXY if already present variant 2", function() {
+      process.env.HTTP_PROXY = "test";
+      process.env.NO_PROXY = " 127.0.0.1 ";
+      upstreamProxyConfigurator.processNoProxyLoopback();
+      expect(process.env.NO_PROXY).to.equal("127.0.0.1,localhost");
+    });
+
+    it("should not add 127.0.0.1 to NO_PROXY if already present variant 3", function() {
+      process.env.HTTP_PROXY = "test";
+      process.env.NO_PROXY = "google.com, 127.0.0.1 , ello.com";
+      upstreamProxyConfigurator.processNoProxyLoopback();
+      expect(process.env.NO_PROXY).to.equal(
+        "google.com,127.0.0.1,ello.com,localhost"
+      );
+    });
+
+    it("should not add 127.0.0.1 to NO_PROXY if already present variant 4", function() {
+      process.env.HTTP_PROXY = "test";
+      process.env.NO_PROXY = "google.com,127.0.0.1,ello.com";
+      upstreamProxyConfigurator.processNoProxyLoopback();
+      expect(process.env.NO_PROXY).to.equal(
+        "google.com,127.0.0.1,ello.com,localhost"
+      );
+    });
+
+    it("should not add anything if both are present", function() {
+      process.env.HTTP_PROXY = "test";
+      process.env.NO_PROXY = "127.0.0.1, localhost, google.com";
+      upstreamProxyConfigurator.processNoProxyLoopback();
+      expect(process.env.NO_PROXY).to.equal("127.0.0.1,localhost,google.com");
+    });
+
+    it("should not add anything if <-loopback> is present", function() {
+      process.env.HTTP_PROXY = "test";
+      process.env.NO_PROXY = "ello.com, <-loopback>";
+      upstreamProxyConfigurator.processNoProxyLoopback();
+      expect(process.env.NO_PROXY).to.equal("ello.com, <-loopback>");
+    });
   });
 
-  it("should modify NO_PROXY when HTTP_PROXY is set", function() {
-    process.env.HTTP_PROXY = "test";
-    upstreamProxyConfigurator.processNoProxyLoopback();
-    expect(process.env.NO_PROXY).not.to.be.undefined;
-  });
+  describe("removeUnusedProxyEnv", function() {
+    it("should not modify HTTP_PROXY or NO_PROXY", function() {
+      process.env.HTTP_PROXY = "test";
+      process.env.NO_PROXY = "ello.com";
+      upstreamProxyConfigurator.removeUnusedProxyEnv();
+      expect(process.env.HTTP_PROXY).to.equal("test");
+      expect(process.env.NO_PROXY).to.equal("ello.com");
+    });
 
-  it("should modify NO_PROXY when HTTPS_PROXY is set", function() {
-    process.env.HTTPS_PROXY = "test";
-    upstreamProxyConfigurator.processNoProxyLoopback();
-    expect(process.env.NO_PROXY).not.to.be.undefined;
-  });
-
-  it("should add both localhost and 127.0.0.1 to NO_PROXY", function() {
-    process.env.HTTP_PROXY = "test";
-    upstreamProxyConfigurator.processNoProxyLoopback();
-    expect(process.env.NO_PROXY).to.equal("localhost,127.0.0.1");
-  });
-
-  it("should not add localhost to NO_PROXY if already present variant 1", function() {
-    process.env.HTTP_PROXY = "test";
-    process.env.NO_PROXY = "localhost";
-    upstreamProxyConfigurator.processNoProxyLoopback();
-    expect(process.env.NO_PROXY).to.equal("localhost,127.0.0.1");
-  });
-
-  it("should not add localhost to NO_PROXY if already present variant 2", function() {
-    process.env.HTTP_PROXY = "test";
-    process.env.NO_PROXY = " localhost ";
-    upstreamProxyConfigurator.processNoProxyLoopback();
-    expect(process.env.NO_PROXY).to.equal("localhost,127.0.0.1");
-  });
-
-  it("should not add localhost to NO_PROXY if already present variant 3", function() {
-    process.env.HTTP_PROXY = "test";
-    process.env.NO_PROXY = "google.com, localhost , ello.com";
-    upstreamProxyConfigurator.processNoProxyLoopback();
-    expect(process.env.NO_PROXY).to.equal(
-      "google.com,localhost,ello.com,127.0.0.1"
-    );
-  });
-
-  it("should not add localhost to NO_PROXY if already present variant 4", function() {
-    process.env.HTTP_PROXY = "test";
-    process.env.NO_PROXY = "google.com,localhost,ello.com";
-    upstreamProxyConfigurator.processNoProxyLoopback();
-    expect(process.env.NO_PROXY).to.equal(
-      "google.com,localhost,ello.com,127.0.0.1"
-    );
-  });
-
-  it("should not add 127.0.0.1 to NO_PROXY if already present variant 1", function() {
-    process.env.HTTP_PROXY = "test";
-    process.env.NO_PROXY = "127.0.0.1";
-    upstreamProxyConfigurator.processNoProxyLoopback();
-    expect(process.env.NO_PROXY).to.equal("127.0.0.1,localhost");
-  });
-
-  it("should not add 127.0.0.1 to NO_PROXY if already present variant 2", function() {
-    process.env.HTTP_PROXY = "test";
-    process.env.NO_PROXY = " 127.0.0.1 ";
-    upstreamProxyConfigurator.processNoProxyLoopback();
-    expect(process.env.NO_PROXY).to.equal("127.0.0.1,localhost");
-  });
-
-  it("should not add 127.0.0.1 to NO_PROXY if already present variant 3", function() {
-    process.env.HTTP_PROXY = "test";
-    process.env.NO_PROXY = "google.com, 127.0.0.1 , ello.com";
-    upstreamProxyConfigurator.processNoProxyLoopback();
-    expect(process.env.NO_PROXY).to.equal(
-      "google.com,127.0.0.1,ello.com,localhost"
-    );
-  });
-
-  it("should not add 127.0.0.1 to NO_PROXY if already present variant 4", function() {
-    process.env.HTTP_PROXY = "test";
-    process.env.NO_PROXY = "google.com,127.0.0.1,ello.com";
-    upstreamProxyConfigurator.processNoProxyLoopback();
-    expect(process.env.NO_PROXY).to.equal(
-      "google.com,127.0.0.1,ello.com,localhost"
-    );
-  });
-
-  it("should not add anything if both are present", function() {
-    process.env.HTTP_PROXY = "test";
-    process.env.NO_PROXY = "127.0.0.1, localhost, google.com";
-    upstreamProxyConfigurator.processNoProxyLoopback();
-    expect(process.env.NO_PROXY).to.equal("127.0.0.1,localhost,google.com");
-  });
-
-  it("should not add anything if <-loopback> is present", function() {
-    process.env.HTTP_PROXY = "test";
-    process.env.NO_PROXY = "ello.com, <-loopback>";
-    upstreamProxyConfigurator.processNoProxyLoopback();
-    expect(process.env.NO_PROXY).to.equal("ello.com, <-loopback>");
+    it("should remove lowercase proxy settings and HTTPS_PROXY", function() {
+      process.env.HTTPS_PROXY = "test";
+      process.env.http_proxy = "test";
+      process.env.https_proxy = "test";
+      process.env.no_proxy = "test";
+      process.env.npm_config_proxy = "test";
+      process.env.npm_config_https_proxy = "test";
+      upstreamProxyConfigurator.removeUnusedProxyEnv();
+      expect(process.env.HTTPS_PROXY).to.be.undefined;
+      expect(process.env.http_proxy).to.be.undefined;
+      expect(process.env.https_proxy).to.be.undefined;
+      expect(process.env.no_proxy).to.be.undefined;
+      expect(process.env.npm_config_proxy).to.be.undefined;
+      expect(process.env.npm_config_https_proxy).to.be.undefined;
+    });
   });
 });


### PR DESCRIPTION
- Updated fix #101 - Override additional unused proxy environment variables before launching cypress to avoid conflicting configurations.