### PR TITLE
Change encoding to be based on NEGOTIATE_UNICODE flag instead of NTLM…

### DIFF
--- a/src/ntlm/type2.message.ts
+++ b/src/ntlm/type2.message.ts
@@ -30,7 +30,7 @@ export class Type2Message {
     // read flags
     this.flags = buf.readUInt32LE(20);
 
-    this.encoding = this.flags & NtlmFlags.NEGOTIATE_OEM ? "ascii" : "ucs2";
+    this.encoding = this.flags & NtlmFlags.NEGOTIATE_UNICODE ?  "ucs2" :  "ascii";
 
     this.version = this.flags & NtlmFlags.NEGOTIATE_NTLM2_KEY ? 2 : 1;
 


### PR DESCRIPTION
https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-nlmp/99d90ff4-957f-4c8a-80e4-5bfe5a9a9832 

From the Microsoft spec
B (1 bit): If set, requests OEM character set encoding. An alternate name for this field is NTLM_NEGOTIATE_OEM. See bit A for details.
A (1 bit): If set, requests [Unicode](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-nlmp/780943e9-42e6-4dbe-aa87-1dce828ba82a#gt_c305d0ab-8b94-461a-bd76-13b40cb8c4d8) character set encoding. An alternate name for this field is NTLMSSP_NEGOTIATE_UNICODE.

The A and B bits are evaluated together as follows:
A==1: The choice of character set encoding MUST be Unicode.
A==0 and B==1: The choice of character set encoding MUST be OEM.
A==0 and B==0: The protocol MUST return SEC_E_INVALID_TOKEN.


Currently we are testing base on B=1, where regardless of the value of B, if A=1 then we should be using unicode.